### PR TITLE
chore: stop using deprecated nix option

### DIFF
--- a/flakes/shell-config/shell-init.sh
+++ b/flakes/shell-config/shell-init.sh
@@ -137,7 +137,7 @@ nfu () {
     if [ -z "$input_name" ]; then
         nix flake update
     else
-        nix flake lock --update-input "$input_name"
+        nix flake update "$input_name"
     fi
 }
 


### PR DESCRIPTION
This will suppress the following warning:
```
warning: '--update-input' is a deprecated alias for 'flake update' and will be removed in a future version.
```