### PR TITLE
chore(nvim): bump inputs

### DIFF
--- a/flakes/nvim/flake.lock
+++ b/flakes/nvim/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1735492891,
-        "narHash": "sha256-J0+IMskN8IkI7o4GRZsJ49i5fDYbbH4bIYFV39ntrQs=",
+        "lastModified": 1740246267,
+        "narHash": "sha256-T8uDeKMeu8W/6uthCzf2kyH9k2ReomVdh3taPVhzTng=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5dfc603d98983cec9353a6e4d769ddc0ba21f8a3",
+        "rev": "a2ce3eeb2ea0330bc0a02fb0a1b3286f3223c292",
         "type": "github"
       },
       "original": {

--- a/flakes/nvim/flake.nix
+++ b/flakes/nvim/flake.nix
@@ -119,7 +119,7 @@
 
                   # Colorschemes
                   sonokai
-                  gruvbox
+                  gruvbox-nvim
                   vim-noctu
                 ];
                 opt = [];

--- a/flakes/nvim/init.lua
+++ b/flakes/nvim/init.lua
@@ -1039,6 +1039,18 @@ local function configure_commenting()
   end
 end
 
+local function configure_colors()
+  if not pcall(require, 'gruvbox') then
+    print('gruvbox is not installed.')
+    return
+  end
+  require('gruvbox').setup({
+    palette_overrides = {
+      bright_green = '#990000',
+    },
+  })
+end
+
 local function configure_toggleterm()
   if not pcall(require, 'toggleterm') then
     print('toggleterm is not installed.')
@@ -1371,6 +1383,7 @@ local function configure()
   configure_copilot()
   configure_codecompanion()
   configure_toggleterm()
+  configure_colors()
 
   -- FIXME this is a workaround for the bug described in issue #30985 of the GitHub neovim repo.
   for _, method in ipairs({ 'textDocument/diagnostic', 'workspace/diagnostic' }) do


### PR DESCRIPTION
This also notably switches to the Lua version of the gruvbox colorscheme